### PR TITLE
Add JCE Unlimited Strength Jurisdiction Policy Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 jdk-*-linux-*.bin
+jce_policy-*.zip
 i586-jdk
 x64-jdk
 tmp-i586
 tmp-x64
 tmp-jdk.zip
+jce
 
 debian/JAVA_HOME
 debian/README.alternatives

--- a/README
+++ b/README
@@ -42,6 +42,8 @@ To create packages on your own:
 - Download jdk-6u32-linux-i586.bin and jdk-6u32-linux-x64.bin from
   http://www.oracle.com/technetwork/java/javase/downloads/index.html
   (yes, both, no matter which version you will run)
+- Download jce_policy-6.zip from the same page under "Java Cryptography
+  Extension (JCE) Unlimited Strength Jurisdiction Policy Files 6"
 - dpkg-buildpackage -b -uc -us
 - install any missing packages that dpkg-buildpackage complains about
   and repeat

--- a/debian/JB-jre.README.Debian.in
+++ b/debian/JB-jre.README.Debian.in
@@ -44,17 +44,10 @@ Java Plug-In:
 
 Java Cryptography Extension (JCE) support:
 ==========================================
-For legal reason, JCE support in this environment is limited to
-smaller key sizes.  Please see
-<http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html>
-for the Unlimited Strength Jurisdiction Policy Files. It is recommended to use
-dpkg-divert before replacing installed files to avoid upgrade problems in the
-future:
-
-  sudo dpkg-divert --rename /@basedir@/jre/lib/security/local_policy.jar
-  sudo dpkg-divert --rename /@basedir@/jre/lib/security/US_export_policy.jar
-
-That change can be reverted through:
+JCE unlimited strength jurisdiction policy files are now included by default,
+older versions of this package recommended to use dpkg-divert before replacing
+installed files to avoid upgrade problems, you can keep those diverted files
+or revert to use the included files:
 
   sudo dpkg-divert --rename --remove /@basedir@/jre/lib/security/local_policy.jar
   sudo dpkg-divert --rename --remove /@basedir@/jre/lib/security/US_export_policy.jar

--- a/debian/rules
+++ b/debian/rules
@@ -277,7 +277,7 @@ compare-jre-jars:
 diff_ignore = -I 'Thursday, April 5' \
 	-I 'Thu Apr 05' -I '^ *// java GenerateCharacter'
 
-unpack-stamp: $(foreach a, $(all_archs), unpack-$(a)-stamp)
+unpack-stamp: $(foreach a, $(all_archs), unpack-$(a)-stamp) unpack-jce-stamp
 	: # check for identical files / trees
 	set -e; set -- $(all_archs); a1=$$1; shift; \
 	for a2; do \
@@ -362,11 +362,16 @@ unpack-%-stamp: $(bin_pattern)
 
 	touch $@
 
+unpack-jce-stamp:
+	rm -rf jce
+	unzip -q jce_policy-$(version).zip
+	touch $@
+
 clean:
 	dh_testdir
 	dh_testroot
 	rm -f *-stamp
-	rm -rf x64-jdk i586-jdk tmp-* $(unpackdir)
+	rm -rf x64-jdk i586-jdk jce tmp-* $(unpackdir)
 	rm -f debian/*.debhelper debian/control.old
 	rm -f debian/$(p_jbin).substvars.tmp
 
@@ -632,6 +637,9 @@ binary-$(p_jre):	build
 
 	: # these are only in the i586 archive
 	cp -a i586-jdk/jre/lib/images/icons $(d_jre)/$(basedir)/jre/lib/images/
+
+	: # JCE Unlimited Strength Jurisdiction Policy
+	cp -a jce/*.jar $(d_jre)/$(basedir)/jre/lib/security/
 
 	: # add lintian overrides
 	cp -p debian/$(p_jre).overrides \


### PR DESCRIPTION
This adds strong cryptography policies to JCE which is required by some applications and is provided by default in openJDK.
