### PR TITLE
Add tzupdater 1.3.47-2012c support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 jdk-*-linux-*.bin
 jce_policy-*.zip
+tzupdater-*
 i586-jdk
 x64-jdk
 tmp-i586

--- a/README
+++ b/README
@@ -44,6 +44,8 @@ To create packages on your own:
   (yes, both, no matter which version you will run)
 - Download jce_policy-6.zip from the same page under "Java Cryptography
   Extension (JCE) Unlimited Strength Jurisdiction Policy Files 6"
+- Download tzupdater-1_3_47-2012c.zip from the same page under "JDK DST
+  Timezone Update Tool"
 - dpkg-buildpackage -uc -us
 - install any missing packages that dpkg-buildpackage complains about
   and repeat

--- a/debian/rules
+++ b/debian/rules
@@ -33,6 +33,8 @@ dirpartsv	:= $(shell dpkg-parsechangelog | sed -ne '/Version:/ s,Version: \(.*\)
 version		:= $(word 1, $(dirpartsv))
 releng_ver	:= $(word 2, $(dirpartsv))
 jdkversion	:= 1.$(version).0
+tzversion	:= 1_3_47-2012c
+tzdirversion	:= $(subst _,.,$(tzversion))
 unpackdir	:= jdk$(jdkversion)_$(releng_ver)
 jdirname	:= $(ia32_prefix)java-$(version)-$(VENDOR)-$(jdkversion).$(releng_ver)
 jdiralias	:= $(ia32_prefix)java-$(version)-$(VENDOR)
@@ -88,6 +90,7 @@ info:
 	@echo 'basename    = $(basename)'
 	@echo 'version     = $(version)'
 	@echo 'releng_ver  = $(releng_ver)'
+	@echo 'tzversion   = $(tzversion)'
 	@echo 'unpackdir   = $(unpackdir)'
 	@echo 'srcdir      = $(srcdir)'
 	@echo 'all_archs   = $(all_archs)'
@@ -277,7 +280,7 @@ compare-jre-jars:
 diff_ignore = -I 'Thursday, April 5' \
 	-I 'Thu Apr 05' -I '^ *// java GenerateCharacter'
 
-unpack-stamp: $(foreach a, $(all_archs), unpack-$(a)-stamp) unpack-jce-stamp
+unpack-stamp: unpack-tzupdater-stamp $(foreach a, $(all_archs), unpack-$(a)-stamp) unpack-jce-stamp
 	: # check for identical files / trees
 	set -e; set -- $(all_archs); a1=$$1; shift; \
 	for a2; do \
@@ -360,6 +363,10 @@ unpack-%-stamp: $(bin_pattern)
 	: # fix permissions
 	-find $*-jdk -name '*.properties' -o -name '*.xml' | xargs chmod 644
 
+	: # Update tzdata
+	$*-jdk/jre/bin/java -jar tzupdater-$(tzdirversion)/tzupdater.jar -u
+	rm -rf $*-jdk/jre/lib/zi.tzdata20[1-9][0-9][a-z]
+
 	touch $@
 
 unpack-jce-stamp:
@@ -367,11 +374,16 @@ unpack-jce-stamp:
 	unzip -q jce_policy-$(version).zip
 	touch $@
 
+unpack-tzupdater-stamp:
+	rm -rf tzupdater-$(tzdirversion)
+	unzip -q tzupdater-$(tzversion).zip
+	touch $@
+
 clean:
 	dh_testdir
 	dh_testroot
 	rm -f *-stamp
-	rm -rf x64-jdk i586-jdk jce tmp-* $(unpackdir)
+	rm -rf x64-jdk i586-jdk jce tzupdater-$(tzdirversion) tmp-* $(unpackdir)
 	rm -f debian/*.debhelper debian/control.old
 	rm -f debian/$(p_jbin).substvars.tmp
 


### PR DESCRIPTION
I was wondering what's the best way to have up to date tzdata in the jre. I integrated the latest tzupdater from oracle in the package build but maybe it would be better to use the tzdata-java package that exist in debian and ubuntu and seems to be kept reasonably up to date.

The "/usr/lib/jvm/java-6-sun-1.6.0.32/jre/lib/zi" would need to be replaced by a symlink to "/usr/share/javazi" and a dependency on tzdata-java would need to be added to the jre package.

What would be your preferred solution?
