### PR TITLE
Add links for machine dependent include files

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -676,6 +676,11 @@ binary-$(p_jdk):	build
 	  ln -sf jre/$$i $(d_jdk)/$(basedir)/$$i; \
 	done
 
+	# add links to machine dependent include files
+	for i in jawt_md.h jni_md.h; do \
+	  ln -sf linux/$$i $(d_jdk)/$(basedir)/include/$$i; \
+	done
+
 	: # remove any runtime files from the jdk package
 	-find $(d_jbin)/$(basedir)/jre/bin \! -type d \
 		-printf "$(d_jdk)/$(basedir)/bin/%P\0" | xargs -r0 rm -f


### PR DESCRIPTION
jawt.h and jni.h in /usr/lib/jvm/java-6-sun/include expect the machine
dependent include files in directory /usr/lib/jvm/java_6-sun/include,
otherwise compilation for JNI fails. Add links from include directory
to jni_md.h -> linux/jni_md.h and jawt_md.h -> linux/jawt_md.h.

The same fix could be used for oracle-java7.
